### PR TITLE
Change channel website placeholder to hyperlink by default

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -340,7 +340,7 @@
   "Create Backup": "Create Backup",
   "Submit": "Submit",
   "Website": "Website",
-  "aprettygoodsite.com": "aprettygoodsite.com",
+  "aprettygoodsite.com": "https://aprettygoodsite.com",
   "yourstruly@example.com": "yourstruly@example.com",
   "Editing": "Editing",
   "Editing Your Channel": "Editing Your Channel",


### PR DESCRIPTION
## Fixes

Issue Number: #3153

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Placeholder doesn't include `https://`.

## What is the new behavior?

Placeholder includes `https://`.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
NA

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
